### PR TITLE
Alert on number of hosts

### DIFF
--- a/bin/check-graphite-data.rb
+++ b/bin/check-graphite-data.rb
@@ -44,6 +44,12 @@ class CheckGraphiteData < Sensu::Plugin::Check::CLI
     long: '--reset INTERVAL',
     proc: proc(&:to_i)
 
+  option :allowed_graphite_age, 
+         description: 'Allowed number of seconds since last data update (default: 60 seconds)',
+         short: '-a SECONDS',
+         long: '--age SECONDS',
+         default: 60,
+         proc: proc(&:to_i)
 
   # Run checks
   def run
@@ -62,8 +68,7 @@ class CheckGraphiteData < Sensu::Plugin::Check::CLI
       end
 
       ok("#{name} value okay")
-    rescue SensuPluginsGraphite::GraphiteProxy::ProxyException => e
-      puts e.backtrace
+    rescue SensuPluginsGraphite::GraphiteProxy::ProxyError => e
       unknown e.message
     end
   end

--- a/bin/check-graphite-data.rb
+++ b/bin/check-graphite-data.rb
@@ -31,48 +31,13 @@ require 'json'
 require 'open-uri'
 require 'openssl'
 
+require 'sensu-plugins-graphite/graphite_proxy/options'
+require 'sensu-plugins-graphite/graphite_proxy/proxy'
+
+
 class CheckGraphiteData < Sensu::Plugin::Check::CLI
-  option :target,
-         description: 'Graphite data target',
-         short: '-t TARGET',
-         long: '--target TARGET',
-         required: true
-
-  option :server,
-         description: 'Server host and port',
-         short: '-s SERVER:PORT',
-         long: '--server SERVER:PORT',
-         required: true
-
-  option :username,
-         description: 'username for basic http authentication',
-         short: '-u USERNAME',
-         long: '--user USERNAME',
-         required: false
-
-  option :password,
-         description: 'user password for basic http authentication',
-         short: '-p PASSWORD',
-         long: '--pass PASSWORD',
-         required: false
-
-  option :passfile,
-         description: 'password file path for basic http authentication',
-         short: '-P PASSWORDFILE',
-         long: '--passfile PASSWORDFILE',
-         required: false
-
-  option :warning,
-         description: 'Generate warning if given value is above received value',
-         short: '-w VALUE',
-         long: '--warn VALUE',
-         proc: proc(&:to_f)
-
-  option :critical,
-         description: 'Generate critical if given value is above received value',
-         short: '-c VALUE',
-         long: '--critical VALUE',
-         proc: proc(&:to_f)
+  
+  include SensuPluginsGraphite::GraphiteProxy::Options
 
   option :reset_on_decrease,
          description: 'Send OK if value has decreased on any values within END-INTERVAL to END',
@@ -80,51 +45,7 @@ class CheckGraphiteData < Sensu::Plugin::Check::CLI
          long: '--reset INTERVAL',
          proc: proc(&:to_i)
 
-  option :name,
-         description: 'Name used in responses',
-         short: '-n NAME',
-         long: '--name NAME',
-         default: 'graphite check'
-
-  option :allowed_graphite_age,
-         description: 'Allowed number of seconds since last data update (default: 60 seconds)',
-         short: '-a SECONDS',
-         long: '--age SECONDS',
-         default: 60,
-         proc: proc(&:to_i)
-
-  option :hostname_sub,
-         description: 'Character used to replace periods (.) in hostname (default: _)',
-         short: '-s CHARACTER',
-         long: '--host-sub CHARACTER'
-
-  option :from,
-         description: 'Get samples starting from FROM (default: -10mins)',
-         short: '-f FROM',
-         long: '--from FROM',
-         default: '-10mins'
-
-  option :below,
-         description: 'warnings/critical if values below specified thresholds',
-         short: '-b',
-         long: '--below'
-
-  option :no_ssl_verify,
-         description: 'Do not verify SSL certs',
-         short: '-v',
-         long: '--nosslverify'
-
-  option :help,
-         description: 'Show this message',
-         short: '-h',
-         long: '--help'
-
-  option :auth,
-         description: 'Add an auth token to the HTTP request, in the form of "Name: Value",
-                                     e.g. --auth yourapitokenvaluegoeshere',
-         short: '-a TOKEN',
-         long: '--auth TOKEN'
-
+  
   # Run checks
   def run
     if config[:help]
@@ -132,13 +53,20 @@ class CheckGraphiteData < Sensu::Plugin::Check::CLI
       exit
     end
 
-    data = retrieve_data
-    data.each_pair do |_key, value|
-      @value = value
-      @data = value['data']
-      check_age || check(:critical) || check(:warning)
+    proxy = SensuPluginsGraphite::GraphiteProxy::Proxy.new(config)
+    begin
+      results = proxy.retrieve_data!
+      results.each_pair do |_key, value|
+       @value = value
+       @data = value['data']
+       check_age || check(:critical) || check(:warning)
+     end
+
+      ok("#{name} value okay")
+    rescue SensuPluginsGraphite::GraphiteProxy::ProxyException => e
+      puts e.backtrace
+      unknown e.message
     end
-    ok("#{name} value okay")
   end
 
   # name used in responses
@@ -155,88 +83,12 @@ class CheckGraphiteData < Sensu::Plugin::Check::CLI
     end
   end
 
-  def format_url_opts(given_opts)
-    url_opts = {}
-
-    if given_opts[:no_ssl_verify]
-      url_opts[:ssl_verify_mode] = OpenSSL::SSL::VERIFY_NONE
-    end
-
-    if given_opts[:username] && (given_opts[:password] || given_opts[:passfile])
-      if given_opts[:passfile]
-        pass = File.open(given_opts[:passfile]).readline
-      elsif given_opts[:password]
-        pass = given_opts[:password]
-      end
-
-      url_opts[:http_basic_authentication] = [given_opts[:username], pass.chomp]
-    end # we don't have both username and password trying without
-
-    if given_opts[:auth]
-      header = "Bearer #{given_opts[:auth]}"
-      url_opts['Authorization'] = header
-    end
-
-    url_opts
-  end
-
-  def format_output
-    output = {}
-    @json_data.each do |raw|
-      raw['datapoints'].delete_if { |v| v.first.nil? }
-      next if raw['datapoints'].empty?
-      target = raw['target']
-      data = raw['datapoints'].map(&:first)
-      start = raw['datapoints'].first.last
-      dend = raw['datapoints'].last.last
-      step = ((dend - start) / raw['datapoints'].size.to_f).ceil
-      output[target] = { 'target' => target, 'data' => data, 'start' => start, 'end' => dend, 'step' => step }
-    end
-    output
-  end
-
-  # grab data from graphite
-  def retrieve_data
-    # #YELLOW
-    unless @raw_data # rubocop:disable GuardClause
-      begin
-        unless config[:server].start_with?('https://', 'http://')
-          config[:server].prepend('http://')
-        end
-
-        url = "#{config[:server]}/render?format=json&target=#{formatted_target}&from=#{config[:from]}"
-
-        handle = open(url, format_url_opts(config))
-
-        @raw_data = handle.gets
-        if @raw_data == '[]'
-          unknown 'Empty data received from Graphite - metric probably doesn\'t exists'
-        else
-          @json_data = JSON.parse(@raw_data)
-          format_output
-        end
-      rescue OpenURI::HTTPError
-        unknown 'Failed to connect to graphite server'
-      rescue NoMethodError
-        unknown 'No data for time period and/or target'
-      rescue Errno::ECONNREFUSED
-        unknown 'Connection refused when connecting to graphite server'
-      rescue Errno::ECONNRESET
-        unknown 'Connection reset by peer when connecting to graphite server'
-      rescue EOFError
-        unknown 'End of file error when reading from graphite server'
-      rescue => e
-        unknown "An unknown error occured: #{e.inspect}"
-      end
-    end
-  end
-
   # type:: :warning or :critical
   # Return alert if required
   def check(type)
     # #YELLOW
     if config[type] # rubocop:disable GuardClause
-      send(type, "#{@value['target']} has passed #{type} threshold (#{@data.last})") if below?(type) || above?(type)
+      send(type, "value (#{@data.last}) for #{@value['target']} has passed #{type} threshold (#{config[type]})") if below?(type) || above?(type)
     end
   end
 
@@ -261,14 +113,4 @@ class CheckGraphiteData < Sensu::Plugin::Check::CLI
     end
   end
 
-  # Returns formatted target with hostname replacing any $ characters
-  def formatted_target
-    if config[:target].include?('$')
-      require 'socket'
-      @formatted = Socket.gethostbyname(Socket.gethostname).first.gsub('.', config[:hostname_sub] || '_')
-      config[:target].gsub('$', @formatted)
-    else
-      URI.escape config[:target]
-    end
-  end
 end

--- a/bin/check-graphite-data.rb
+++ b/bin/check-graphite-data.rb
@@ -34,18 +34,17 @@ require 'openssl'
 require 'sensu-plugins-graphite/graphite_proxy/options'
 require 'sensu-plugins-graphite/graphite_proxy/proxy'
 
-
 class CheckGraphiteData < Sensu::Plugin::Check::CLI
-  
+
   include SensuPluginsGraphite::GraphiteProxy::Options
 
   option :reset_on_decrease,
-         description: 'Send OK if value has decreased on any values within END-INTERVAL to END',
-         short: '-r INTERVAL',
-         long: '--reset INTERVAL',
-         proc: proc(&:to_i)
+    description: 'Send OK if value has decreased on any values within END-INTERVAL to END',
+    short: '-r INTERVAL',
+    long: '--reset INTERVAL',
+    proc: proc(&:to_i)
 
-  
+
   # Run checks
   def run
     if config[:help]
@@ -57,10 +56,10 @@ class CheckGraphiteData < Sensu::Plugin::Check::CLI
     begin
       results = proxy.retrieve_data!
       results.each_pair do |_key, value|
-       @value = value
-       @data = value['data']
-       check_age || check(:critical) || check(:warning)
-     end
+        @value = value
+        @data = value['data']
+        check_age || check(:critical) || check(:warning)
+      end
 
       ok("#{name} value okay")
     rescue SensuPluginsGraphite::GraphiteProxy::ProxyException => e

--- a/bin/check-graphite-hosts.rb
+++ b/bin/check-graphite-hosts.rb
@@ -34,96 +34,11 @@ require 'openssl'
 require 'byebug'
 
 require 'sensu-plugins-graphite/graphite_proxy/options'
+require 'sensu-plugins-graphite/graphite_proxy/proxy'
 
 class CheckGraphiteHosts < Sensu::Plugin::Check::CLI
 
   include SensuPluginsGraphite::GraphiteProxy::Options
-  # option :target,
-  #        description: 'Graphite data target',
-  #        short: '-t TARGET',
-  #        long: '--target TARGET',
-  #        required: true
-
-  # option :server,
-  #        description: 'Server host and port',
-  #        short: '-s SERVER:PORT',
-  #        long: '--server SERVER:PORT',
-  #        required: true
-
-  # option :username,
-  #        description: 'username for basic http authentication',
-  #        short: '-u USERNAME',
-  #        long: '--user USERNAME',
-  #        required: false
-
-  # option :password,
-  #        description: 'user password for basic http authentication',
-  #        short: '-p PASSWORD',
-  #        long: '--pass PASSWORD',
-  #        required: false
-
-  # option :passfile,
-  #        description: 'password file path for basic http authentication',
-  #        short: '-P PASSWORDFILE',
-  #        long: '--passfile PASSWORDFILE',
-  #        required: false
-
-  # option :no_ssl_verify,
-  #        description: 'Do not verify SSL certs',
-  #        short: '-v',
-  #        long: '--nosslverify'
-
-  # option :help,
-  #        description: 'Show this message',
-  #        short: '-h',
-  #        long: '--help'
-
-  # option :auth,
-  #        description: 'Add an auth token to the HTTP request, in the form of "Name: Value",
-  #                                    e.g. --auth yourapitokenvaluegoeshere',
-  #        short: '-a TOKEN',
-  #        long: '--auth TOKEN'
-
-  # option :name,
-  #        description: 'Name used in responses',
-  #        short: '-n NAME',
-  #        long: '--name NAME',
-  #        default: 'graphite check'
-
-  # option :allowed_graphite_age,
-  #        description: 'Allowed number of seconds since last data update (default: 60 seconds)',
-  #        short: '-a SECONDS',
-  #        long: '--age SECONDS',
-  #        default: 60,
-  #        proc: proc(&:to_i)
-
-  # option :hostname_sub,
-  #        description: 'Character used to replace periods (.) in hostname (default: _)',
-  #        short: '-s CHARACTER',
-  #        long: '--host-sub CHARACTER'
-
-  # option :from,
-  #        description: 'Get samples starting from FROM (default: -10mins)',
-  #        short: '-f FROM',
-  #        long: '--from FROM',
-  #        default: '-10mins'
-
-  # option :warning,
-  #        description: 'Generate warning if number of hosts is below received value',
-  #        short: '-w VALUE',
-  #        long: '--warn VALUE',
-  #        proc: proc(&:to_f)
-
-  # option :critical,
-  #        description: 'Generate critical if number of hosts is below received value',
-  #        short: '-c VALUE',
-  #        long: '--critical VALUE',
-  #        proc: proc(&:to_f)
-
-  # option :below,
-  #        description: 'alert if number of hosts below specified thresholds',
-  #        short: '-b',
-  #        long: '--below'
 
   # Run checks
   def run
@@ -132,10 +47,16 @@ class CheckGraphiteHosts < Sensu::Plugin::Check::CLI
       exit
     end
 
-    results = retrieve_data
-    check_age(results) || check(:critical, results) || check(:warning, results)
+    proxy = SensuPluginsGraphite::GraphiteProxy::Proxy.new(config)
+    begin
+      results = proxy.retrieve_data!
+      check_age(results) || check(:critical, results) || check(:warning, results)
   
-    ok("#{name} value (#{hosts_with_data(results)}) okay")
+      ok("#{name} value (#{hosts_with_data(results)}) okay")
+    rescue SensuPluginsGraphite::GraphiteProxy::ProxyException => e
+      puts e.backtrace
+      unknown e.message
+    end
   end
 
   # name used in responses
@@ -156,88 +77,10 @@ class CheckGraphiteHosts < Sensu::Plugin::Check::CLI
     nil
   end
 
-  def format_url_opts(given_opts)
-    url_opts = {}
-
-    if given_opts[:no_ssl_verify]
-      url_opts[:ssl_verify_mode] = OpenSSL::SSL::VERIFY_NONE
-    end
-
-    if given_opts[:username] && (given_opts[:password] || given_opts[:passfile])
-      if given_opts[:passfile]
-        pass = File.open(given_opts[:passfile]).readline
-      elsif given_opts[:password]
-        pass = given_opts[:password]
-      end
-
-      url_opts[:http_basic_authentication] = [given_opts[:username], pass.chomp]
-    end # we don't have both username and password trying without
-
-    if given_opts[:auth]
-      header = "Bearer #{given_opts[:auth]}"
-      url_opts['Authorization'] = header
-    end
-
-    url_opts
-  end
-
-  def format_output
-    output = {}
-
-    @json_data.each do |raw|
-      raw['datapoints'].delete_if { |v| v.first.nil? }
-      next if raw['datapoints'].empty?
-      target = raw['target']
-      data = raw['datapoints'].map(&:first)
-      start = raw['datapoints'].first.last
-      dend = raw['datapoints'].last.last
-      step = ((dend - start) / raw['datapoints'].size.to_f).ceil
-      output[target] = { 'target' => target, 'data' => data, 'start' => start, 'end' => dend, 'step' => step }
-    end
-    output
-  end
-
-  # grab data from graphite
-  def retrieve_data
-    # #YELLOW
-    unless @raw_data # rubocop:disable GuardClause
-      begin
-        unless config[:server].start_with?('https://', 'http://')
-          config[:server].prepend('http://')
-        end
-
-        url = "#{config[:server]}/render?format=json&target=#{formatted_target}&from=#{config[:from]}"
-
-        handle = open(url, format_url_opts(config))
-
-        @raw_data = handle.gets
-        if @raw_data == '[]'
-          unknown 'Empty data received from Graphite - metric probably doesn\'t exists'
-        else
-          @json_data = JSON.parse(@raw_data)
-          format_output
-        end
-      rescue OpenURI::HTTPError
-        unknown 'Failed to connect to graphite server'
-      rescue NoMethodError
-        unknown 'No data for time period and/or target'
-      rescue Errno::ECONNREFUSED
-        unknown 'Connection refused when connecting to graphite server'
-      rescue Errno::ECONNRESET
-        unknown 'Connection reset by peer when connecting to graphite server'
-      rescue EOFError
-        unknown 'End of file error when reading from graphite server'
-      rescue => e
-        unknown "An unknown error occured: #{e.inspect}"
-      end
-    end
-  end
-
   # return the number of hosts with data in the given set of results
   def hosts_with_data(resultset)
     resultset.select{|host, values| !values["data"].empty?}.size
   end
-
 
   # type:: :warning or :critical
   # Return alert if required
@@ -259,14 +102,4 @@ class CheckGraphiteHosts < Sensu::Plugin::Check::CLI
     (!config[:below]) && (val > config[type]) 
   end
 
-  # Returns formatted target with hostname replacing any $ characters
-  def formatted_target
-    if config[:target].include?('$')
-      require 'socket'
-      @formatted = Socket.gethostbyname(Socket.gethostname).first.gsub('.', config[:hostname_sub] || '_')
-      config[:target].gsub('$', @formatted)
-    else
-      URI.escape config[:target]
-    end
-  end
 end

--- a/bin/check-graphite-hosts.rb
+++ b/bin/check-graphite-hosts.rb
@@ -49,11 +49,10 @@ class CheckGraphiteHosts < Sensu::Plugin::Check::CLI
     proxy = SensuPluginsGraphite::GraphiteProxy::Proxy.new(config)
     begin
       results = proxy.retrieve_data!
-      check_age(results) || check(:critical, results) || check(:warning, results)
+      check(:critical, results) || check(:warning, results)
 
       ok("#{name} value (#{hosts_with_data(results)}) okay")
-    rescue SensuPluginsGraphite::GraphiteProxy::ProxyException => e
-      puts e.backtrace
+    rescue SensuPluginsGraphite::GraphiteProxy::ProxyError => e
       unknown e.message
     end
   end
@@ -64,17 +63,6 @@ class CheckGraphiteHosts < Sensu::Plugin::Check::CLI
     @formatted ? "#{base} (#{@formatted})" : base
   end
 
-  # Check the age of the data being processed
-  def check_age(results)
-    # #YELLOW
-    hosts_too_old = results.select{ |_host, values| (Time.now.to_i - values['end']) > config[:allowed_graphite_age] }
-    hosts_too_old.each do |host, values|
-      if (Time.now.to_i - values['end']) > config[:allowed_graphite_age]
-        return unknown "Graphite data age for host #{host} is past allowed threshold (#{config[:allowed_graphite_age]} seconds)"
-      end
-    end
-    nil
-  end
 
   # return the number of hosts with data in the given set of results
   def hosts_with_data(resultset)

--- a/bin/check-graphite-hosts.rb
+++ b/bin/check-graphite-hosts.rb
@@ -1,0 +1,272 @@
+#! /usr/bin/env ruby
+#
+#   check-graphite-hosts
+#
+# DESCRIPTION:
+#   This plugin checks the number of hosts within graphite that are sending
+#   data, and alerts if it is below a given threshold
+#
+# OUTPUT:
+#   plain text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#   gem: openssl
+#
+# USAGE:
+#   #YELLOW
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright 2014 Sonian, Inc. and contributors. <support@sensuapp.org>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugin/check/cli'
+require 'json'
+require 'open-uri'
+require 'openssl'
+require 'byebug'
+
+require 'sensu-plugins-graphite/graphite_proxy/options'
+
+class CheckGraphiteHosts < Sensu::Plugin::Check::CLI
+
+  include SensuPluginsGraphite::GraphiteProxy::Options
+  # option :target,
+  #        description: 'Graphite data target',
+  #        short: '-t TARGET',
+  #        long: '--target TARGET',
+  #        required: true
+
+  # option :server,
+  #        description: 'Server host and port',
+  #        short: '-s SERVER:PORT',
+  #        long: '--server SERVER:PORT',
+  #        required: true
+
+  # option :username,
+  #        description: 'username for basic http authentication',
+  #        short: '-u USERNAME',
+  #        long: '--user USERNAME',
+  #        required: false
+
+  # option :password,
+  #        description: 'user password for basic http authentication',
+  #        short: '-p PASSWORD',
+  #        long: '--pass PASSWORD',
+  #        required: false
+
+  # option :passfile,
+  #        description: 'password file path for basic http authentication',
+  #        short: '-P PASSWORDFILE',
+  #        long: '--passfile PASSWORDFILE',
+  #        required: false
+
+  # option :no_ssl_verify,
+  #        description: 'Do not verify SSL certs',
+  #        short: '-v',
+  #        long: '--nosslverify'
+
+  # option :help,
+  #        description: 'Show this message',
+  #        short: '-h',
+  #        long: '--help'
+
+  # option :auth,
+  #        description: 'Add an auth token to the HTTP request, in the form of "Name: Value",
+  #                                    e.g. --auth yourapitokenvaluegoeshere',
+  #        short: '-a TOKEN',
+  #        long: '--auth TOKEN'
+
+  # option :name,
+  #        description: 'Name used in responses',
+  #        short: '-n NAME',
+  #        long: '--name NAME',
+  #        default: 'graphite check'
+
+  # option :allowed_graphite_age,
+  #        description: 'Allowed number of seconds since last data update (default: 60 seconds)',
+  #        short: '-a SECONDS',
+  #        long: '--age SECONDS',
+  #        default: 60,
+  #        proc: proc(&:to_i)
+
+  # option :hostname_sub,
+  #        description: 'Character used to replace periods (.) in hostname (default: _)',
+  #        short: '-s CHARACTER',
+  #        long: '--host-sub CHARACTER'
+
+  # option :from,
+  #        description: 'Get samples starting from FROM (default: -10mins)',
+  #        short: '-f FROM',
+  #        long: '--from FROM',
+  #        default: '-10mins'
+
+  # option :warning,
+  #        description: 'Generate warning if number of hosts is below received value',
+  #        short: '-w VALUE',
+  #        long: '--warn VALUE',
+  #        proc: proc(&:to_f)
+
+  # option :critical,
+  #        description: 'Generate critical if number of hosts is below received value',
+  #        short: '-c VALUE',
+  #        long: '--critical VALUE',
+  #        proc: proc(&:to_f)
+
+  # option :below,
+  #        description: 'alert if number of hosts below specified thresholds',
+  #        short: '-b',
+  #        long: '--below'
+
+  # Run checks
+  def run
+    if config[:help]
+      puts opt_parser if config[:help]
+      exit
+    end
+
+    results = retrieve_data
+    check_age(results) || check(:critical, results) || check(:warning, results)
+  
+    ok("#{name} value (#{hosts_with_data(results)}) okay")
+  end
+
+  # name used in responses
+  def name
+    base = config[:name]
+    @formatted ? "#{base} (#{@formatted})" : base
+  end
+
+  # Check the age of the data being processed
+  def check_age(results)
+    # #YELLOW
+    hosts_too_old = results.select{|host, values| (Time.now.to_i - values['end']) > config[:allowed_graphite_age] }
+    hosts_too_old.each do |host, values|
+      if (Time.now.to_i - @value['end']) > config[:allowed_graphite_age] # rubocop:disable GuardClause
+        return unknown "Graphite data age for host #{host} is past allowed threshold (#{config[:allowed_graphite_age]} seconds)"
+      end
+    end
+    nil
+  end
+
+  def format_url_opts(given_opts)
+    url_opts = {}
+
+    if given_opts[:no_ssl_verify]
+      url_opts[:ssl_verify_mode] = OpenSSL::SSL::VERIFY_NONE
+    end
+
+    if given_opts[:username] && (given_opts[:password] || given_opts[:passfile])
+      if given_opts[:passfile]
+        pass = File.open(given_opts[:passfile]).readline
+      elsif given_opts[:password]
+        pass = given_opts[:password]
+      end
+
+      url_opts[:http_basic_authentication] = [given_opts[:username], pass.chomp]
+    end # we don't have both username and password trying without
+
+    if given_opts[:auth]
+      header = "Bearer #{given_opts[:auth]}"
+      url_opts['Authorization'] = header
+    end
+
+    url_opts
+  end
+
+  def format_output
+    output = {}
+
+    @json_data.each do |raw|
+      raw['datapoints'].delete_if { |v| v.first.nil? }
+      next if raw['datapoints'].empty?
+      target = raw['target']
+      data = raw['datapoints'].map(&:first)
+      start = raw['datapoints'].first.last
+      dend = raw['datapoints'].last.last
+      step = ((dend - start) / raw['datapoints'].size.to_f).ceil
+      output[target] = { 'target' => target, 'data' => data, 'start' => start, 'end' => dend, 'step' => step }
+    end
+    output
+  end
+
+  # grab data from graphite
+  def retrieve_data
+    # #YELLOW
+    unless @raw_data # rubocop:disable GuardClause
+      begin
+        unless config[:server].start_with?('https://', 'http://')
+          config[:server].prepend('http://')
+        end
+
+        url = "#{config[:server]}/render?format=json&target=#{formatted_target}&from=#{config[:from]}"
+
+        handle = open(url, format_url_opts(config))
+
+        @raw_data = handle.gets
+        if @raw_data == '[]'
+          unknown 'Empty data received from Graphite - metric probably doesn\'t exists'
+        else
+          @json_data = JSON.parse(@raw_data)
+          format_output
+        end
+      rescue OpenURI::HTTPError
+        unknown 'Failed to connect to graphite server'
+      rescue NoMethodError
+        unknown 'No data for time period and/or target'
+      rescue Errno::ECONNREFUSED
+        unknown 'Connection refused when connecting to graphite server'
+      rescue Errno::ECONNRESET
+        unknown 'Connection reset by peer when connecting to graphite server'
+      rescue EOFError
+        unknown 'End of file error when reading from graphite server'
+      rescue => e
+        unknown "An unknown error occured: #{e.inspect}"
+      end
+    end
+  end
+
+  # return the number of hosts with data in the given set of results
+  def hosts_with_data(resultset)
+    resultset.select{|host, values| !values["data"].empty?}.size
+  end
+
+
+  # type:: :warning or :critical
+  # Return alert if required
+  def check(type, results)
+    # #YELLOW
+    num_hosts = hosts_with_data(results)
+    if config[type] # rubocop:disable GuardClause
+      send(type, "Number of hosts sending #{config[:target]} (#{num_hosts}) has passed #{type} threshold (#{config[type]})") if below?(type, num_hosts) || above?(type, num_hosts)
+    end
+  end
+
+  # Check if value is below defined threshold
+  def below?(type, val)
+    config[:below] && val < config[type]
+  end
+
+  # Check is value is above defined threshold
+  def above?(type, val)
+    (!config[:below]) && (val > config[type]) 
+  end
+
+  # Returns formatted target with hostname replacing any $ characters
+  def formatted_target
+    if config[:target].include?('$')
+      require 'socket'
+      @formatted = Socket.gethostbyname(Socket.gethostname).first.gsub('.', config[:hostname_sub] || '_')
+      config[:target].gsub('$', @formatted)
+    else
+      URI.escape config[:target]
+    end
+  end
+end

--- a/bin/check-graphite-hosts.rb
+++ b/bin/check-graphite-hosts.rb
@@ -31,7 +31,6 @@ require 'sensu-plugin/check/cli'
 require 'json'
 require 'open-uri'
 require 'openssl'
-require 'byebug'
 
 require 'sensu-plugins-graphite/graphite_proxy/options'
 require 'sensu-plugins-graphite/graphite_proxy/proxy'

--- a/bin/check-graphite-hosts.rb
+++ b/bin/check-graphite-hosts.rb
@@ -50,7 +50,7 @@ class CheckGraphiteHosts < Sensu::Plugin::Check::CLI
     begin
       results = proxy.retrieve_data!
       check_age(results) || check(:critical, results) || check(:warning, results)
-  
+
       ok("#{name} value (#{hosts_with_data(results)}) okay")
     rescue SensuPluginsGraphite::GraphiteProxy::ProxyException => e
       puts e.backtrace
@@ -67,9 +67,9 @@ class CheckGraphiteHosts < Sensu::Plugin::Check::CLI
   # Check the age of the data being processed
   def check_age(results)
     # #YELLOW
-    hosts_too_old = results.select{|host, values| (Time.now.to_i - values['end']) > config[:allowed_graphite_age] }
+    hosts_too_old = results.select{ |_host, values| (Time.now.to_i - values['end']) > config[:allowed_graphite_age] }
     hosts_too_old.each do |host, values|
-      if (Time.now.to_i - @value['end']) > config[:allowed_graphite_age] # rubocop:disable GuardClause
+      if (Time.now.to_i - values['end']) > config[:allowed_graphite_age]
         return unknown "Graphite data age for host #{host} is past allowed threshold (#{config[:allowed_graphite_age]} seconds)"
       end
     end
@@ -78,7 +78,7 @@ class CheckGraphiteHosts < Sensu::Plugin::Check::CLI
 
   # return the number of hosts with data in the given set of results
   def hosts_with_data(resultset)
-    resultset.select{|host, values| !values["data"].empty?}.size
+    resultset.select{ |_host, values| !values["data"].empty? }.count
   end
 
   # type:: :warning or :critical
@@ -86,7 +86,7 @@ class CheckGraphiteHosts < Sensu::Plugin::Check::CLI
   def check(type, results)
     # #YELLOW
     num_hosts = hosts_with_data(results)
-    if config[type] # rubocop:disable GuardClause
+    if config[type]
       send(type, "Number of hosts sending #{config[:target]} (#{num_hosts}) has passed #{type} threshold (#{config[type]})") if below?(type, num_hosts) || above?(type, num_hosts)
     end
   end
@@ -98,7 +98,7 @@ class CheckGraphiteHosts < Sensu::Plugin::Check::CLI
 
   # Check is value is above defined threshold
   def above?(type, val)
-    (!config[:below]) && (val > config[type]) 
+    (!config[:below]) && (val > config[type])
   end
 
 end

--- a/lib/sensu-plugins-graphite/graphite_proxy/options.rb
+++ b/lib/sensu-plugins-graphite/graphite_proxy/options.rb
@@ -75,14 +75,6 @@ module SensuPluginsGraphite
                  default: 'graphite check'
           },
 
-          allowed_graphite_age: {
-                 description: 'Allowed number of seconds since last data update (default: 60 seconds)',
-                 short: '-a SECONDS',
-                 long: '--age SECONDS',
-                 default: 60,
-                 proc: proc(&:to_i)
-          },
-
           hostname_sub: {
                  description: 'Character used to replace periods (.) in hostname (default: _)',
                  short: '-s CHARACTER',

--- a/lib/sensu-plugins-graphite/graphite_proxy/options.rb
+++ b/lib/sensu-plugins-graphite/graphite_proxy/options.rb
@@ -1,0 +1,86 @@
+module SensuPluginsGraphite
+  module GraphiteProxy
+    module Options
+
+      def included(base)
+        base.send(:extend, ClassMethods)
+        byebug
+        base.send(:define_options)
+      end
+
+      module ClassMethods
+        def define_options
+          option :target,
+             description: 'Graphite data target',
+             short: '-t TARGET',
+             long: '--target TARGET',
+             required: true
+
+          option :server,
+                 description: 'Server host and port',
+                 short: '-s SERVER:PORT',
+                 long: '--server SERVER:PORT',
+                 required: true
+
+          option :username,
+                 description: 'username for basic http authentication',
+                 short: '-u USERNAME',
+                 long: '--user USERNAME',
+                 required: false
+
+          option :password,
+                 description: 'user password for basic http authentication',
+                 short: '-p PASSWORD',
+                 long: '--pass PASSWORD',
+                 required: false
+
+          option :passfile,
+                 description: 'password file path for basic http authentication',
+                 short: '-P PASSWORDFILE',
+                 long: '--passfile PASSWORDFILE',
+                 required: false
+
+          option :no_ssl_verify,
+                 description: 'Do not verify SSL certs',
+                 short: '-v',
+                 long: '--nosslverify'
+
+          option :help,
+                 description: 'Show this message',
+                 short: '-h',
+                 long: '--help'
+
+          option :auth,
+                 description: 'Add an auth token to the HTTP request, in the form of "Name: Value",
+                                             e.g. --auth yourapitokenvaluegoeshere',
+                 short: '-a TOKEN',
+                 long: '--auth TOKEN'
+
+          option :name,
+                 description: 'Name used in responses',
+                 short: '-n NAME',
+                 long: '--name NAME',
+                 default: 'graphite check'
+
+          option :allowed_graphite_age,
+                 description: 'Allowed number of seconds since last data update (default: 60 seconds)',
+                 short: '-a SECONDS',
+                 long: '--age SECONDS',
+                 default: 60,
+                 proc: proc(&:to_i)
+
+          option :hostname_sub,
+                 description: 'Character used to replace periods (.) in hostname (default: _)',
+                 short: '-s CHARACTER',
+                 long: '--host-sub CHARACTER'
+
+          option :from,
+                 description: 'Get samples starting from FROM (default: -10mins)',
+                 short: '-f FROM',
+                 long: '--from FROM',
+                 default: '-10mins'
+        end
+      end
+    end
+  end
+end

--- a/lib/sensu-plugins-graphite/graphite_proxy/options.rb
+++ b/lib/sensu-plugins-graphite/graphite_proxy/options.rb
@@ -2,85 +2,122 @@ module SensuPluginsGraphite
   module GraphiteProxy
     module Options
 
-      def included(base)
-        base.send(:extend, ClassMethods)
-        byebug
-        base.send(:define_options)
+      def self.included(base)
+        self.add_default_options(base)
       end
 
-      module ClassMethods
-        def define_options
-          option :target,
-             description: 'Graphite data target',
-             short: '-t TARGET',
-             long: '--target TARGET',
-             required: true
+      def self.add_default_options(base)
+        self.default_options.each do |name, vals|
+          base.send(:option, name, vals)
+        end
+      end
 
-          option :server,
+      def self.default_options
+        {
+          target: {
+               description: 'Graphite data target',
+               short: '-t TARGET',
+               long: '--target TARGET',
+               required: true
+          },
+
+          server: {
                  description: 'Server host and port',
                  short: '-s SERVER:PORT',
                  long: '--server SERVER:PORT',
                  required: true
+          },
 
-          option :username,
+          username: {
                  description: 'username for basic http authentication',
                  short: '-u USERNAME',
                  long: '--user USERNAME',
                  required: false
+          },
 
-          option :password,
+          password: {
                  description: 'user password for basic http authentication',
                  short: '-p PASSWORD',
                  long: '--pass PASSWORD',
                  required: false
+          },
 
-          option :passfile,
+          passfile: {
                  description: 'password file path for basic http authentication',
                  short: '-P PASSWORDFILE',
                  long: '--passfile PASSWORDFILE',
                  required: false
+          },
 
-          option :no_ssl_verify,
+          no_ssl_verify: {
                  description: 'Do not verify SSL certs',
                  short: '-v',
                  long: '--nosslverify'
+          },
 
-          option :help,
+          help: {
                  description: 'Show this message',
                  short: '-h',
                  long: '--help'
+          },
 
-          option :auth,
+          auth: {
                  description: 'Add an auth token to the HTTP request, in the form of "Name: Value",
                                              e.g. --auth yourapitokenvaluegoeshere',
                  short: '-a TOKEN',
                  long: '--auth TOKEN'
+          },
 
-          option :name,
+          name: {
                  description: 'Name used in responses',
                  short: '-n NAME',
                  long: '--name NAME',
                  default: 'graphite check'
+          },
 
-          option :allowed_graphite_age,
+          allowed_graphite_age: {
                  description: 'Allowed number of seconds since last data update (default: 60 seconds)',
                  short: '-a SECONDS',
                  long: '--age SECONDS',
                  default: 60,
                  proc: proc(&:to_i)
+          },
 
-          option :hostname_sub,
+          hostname_sub: {
                  description: 'Character used to replace periods (.) in hostname (default: _)',
                  short: '-s CHARACTER',
                  long: '--host-sub CHARACTER'
+          },
 
-          option :from,
+          from: {
                  description: 'Get samples starting from FROM (default: -10mins)',
                  short: '-f FROM',
                  long: '--from FROM',
                  default: '-10mins'
-        end
+          },
+
+          warning: {
+                 description: 'Generate warning if number of hosts is below received value',
+                 short: '-w VALUE',
+                 long: '--warn VALUE',
+                 proc: proc(&:to_f)
+          },
+
+          critical: {
+                 description: 'Generate critical if number of hosts is below received value',
+                 short: '-c VALUE',
+                 long: '--critical VALUE',
+                 proc: proc(&:to_f)
+          },
+
+          below: {
+                 description: 'alert if number of hosts below specified thresholds',
+                 short: '-b',
+                 long: '--below'
+          }
+        }
       end
+      
     end
   end
 end

--- a/lib/sensu-plugins-graphite/graphite_proxy/proxy.rb
+++ b/lib/sensu-plugins-graphite/graphite_proxy/proxy.rb
@@ -3,7 +3,14 @@ require 'open-uri'
 
 module SensuPluginsGraphite
   module GraphiteProxy
-    class ProxyException < Exception; end
+    class ProxyError < StandardError
+      attr_accessor :exception
+
+      def initialize(msg, args)
+        self.exception = args[:exception]
+        super msg
+      end
+    end
 
     class Proxy
       attr_accessor  :config
@@ -90,17 +97,17 @@ module SensuPluginsGraphite
               format_output(json_data)
             end
           rescue OpenURI::HTTPError => e
-            raise ProxyException.new('Failed to connect to graphite server', exception: e)
+            raise ProxyError.new('Failed to connect to graphite server', exception: e)
           rescue NoMethodError => e
-            raise ProxyException.new('No data for time period and/or target', exception: e)
+            raise ProxyError.new('No data for time period and/or target', exception: e)
           rescue Errno::ECONNREFUSED => e
-            raise ProxyException.new('Connection refused when connecting to graphite server', exception: e)
+            raise ProxyError.new('Connection refused when connecting to graphite server', exception: e)
           rescue Errno::ECONNRESET => e
-            raise ProxyException.new('Connection reset by peer when connecting to graphite server', exception: e)
+            raise ProxyError.new('Connection reset by peer when connecting to graphite server', exception: e)
           rescue EOFError => e
-            raise ProxyException.new('End of file error when reading from graphite server', exception: e)
+            raise ProxyError.new('End of file error when reading from graphite server', exception: e)
           rescue => e
-            raise  ProxyException.new("An unknown error occured: #{e.inspect}", exception: e)
+            raise  ProxyError.new("An unknown error occured: #{e.inspect}", exception: e)
           end
         end
       end

--- a/lib/sensu-plugins-graphite/graphite_proxy/proxy.rb
+++ b/lib/sensu-plugins-graphite/graphite_proxy/proxy.rb
@@ -1,0 +1,109 @@
+require 'open-uri'
+
+
+module SensuPluginsGraphite
+  module GraphiteProxy
+    class ProxyException < Exception; end
+
+    class Proxy
+      attr_accessor  :config
+
+      def initialize(config)
+        self.config = config
+      end
+
+      def formatted_target
+        if config[:target].include?('$')
+          require 'socket'
+          formatted = Socket.gethostbyname(Socket.gethostname).first.gsub('.', config[:hostname_sub] || '_')
+          config[:target].gsub('$', formatted)
+        else
+          URI.escape config[:target]
+        end
+      end
+
+      def request_auth_options(given_opts)
+        url_opts = {}
+
+        url_opts[:ssl_verify_mode] = OpenSSL::SSL::VERIFY_NONE if given_opts[:no_ssl_verify]
+
+        if given_opts[:username] 
+          pass = derive_password(given_opts)
+          url_opts[:http_basic_authentication] = [given_opts[:username], pass.chomp]
+        end # we don't have both username and password trying without
+
+        url_opts['Authorization'] = "Bearer #{given_opts[:auth]}" if given_opts[:auth]
+      
+        url_opts
+      end
+
+      def derive_password(given_opts)
+        if given_opts[:passfile]
+          pass = File.open(given_opts[:passfile]).readline
+        elsif given_opts[:password]
+          pass = given_opts[:password]
+        end
+      end
+
+
+      def format_output(data)
+        output = {}
+
+        data.each do |raw|
+          unless raw['datapoints'].empty?
+            line = output_line(raw)
+            output[line['target']] = line
+          end
+        end
+        output
+      end
+
+      def output_line(raw)
+        raw['datapoints'].delete_if { |v| v.first.nil? }
+        target = raw['target']
+        data = raw['datapoints'].map(&:first)
+        start = raw['datapoints'].first.last
+        dend = raw['datapoints'].last.last
+        step = ((dend - start) / raw['datapoints'].size.to_f).ceil
+
+        { 'target' => target, 'data' => data, 'start' => start, 'end' => dend, 'step' => step }
+      end
+
+      # grab data from graphite
+      def retrieve_data!
+        # #YELLOW
+        unless @raw_data # rubocop:disable GuardClause
+          begin
+            unless config[:server].start_with?('https://', 'http://')
+              config[:server].prepend('http://')
+            end
+
+            url = "#{config[:server]}/render?format=json&target=#{formatted_target}&from=#{config[:from]}"
+
+            handle = open(url, request_auth_options(config))
+
+            @raw_data = handle.gets
+            if @raw_data == '[]'
+              unknown 'Empty data received from Graphite - metric probably doesn\'t exists'
+            else
+              json_data = JSON.parse(@raw_data)
+              format_output(json_data)
+            end
+          rescue OpenURI::HTTPError => e
+            raise ProxyException.new('Failed to connect to graphite server', exception: e)
+          rescue NoMethodError => e
+            raise ProxyException.new('No data for time period and/or target', exception: e)
+          rescue Errno::ECONNREFUSED => e
+            raise ProxyException.new('Connection refused when connecting to graphite server', exception: e)
+          rescue Errno::ECONNRESET => e
+            raise ProxyException.new('Connection reset by peer when connecting to graphite server', exception: e)
+          rescue EOFError => e
+            raise ProxyException.new('End of file error when reading from graphite server', exception: e)
+          rescue => e
+            raise  ProxyException.new("An unknown error occured: #{e.inspect}", exception: e)
+          end
+        end
+      end
+    end
+  end
+end

--- a/sensu-plugins-graphite.gemspec
+++ b/sensu-plugins-graphite.gemspec
@@ -46,9 +46,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'simple-graphite',  '2.1.0'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
-
-  s.add_development_dependency 'byebug'
-
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
   s.add_development_dependency 'github-markup',             '~> 1.3'
   s.add_development_dependency 'pry',                       '~> 0.10'

--- a/sensu-plugins-graphite.gemspec
+++ b/sensu-plugins-graphite.gemspec
@@ -46,6 +46,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'simple-graphite',  '2.1.0'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
+
+  s.add_development_dependency 'byebug'
+
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
   s.add_development_dependency 'github-markup',             '~> 1.3'
   s.add_development_dependency 'pry',                       '~> 0.10'


### PR DESCRIPTION
Added check-graphite-hosts script to alert on number of hosts sending data for a given target.

E.g.

bundle exec ruby ./bin/check-graphite-hosts.rb -s https://(grafana host)/api/datasources/proxy/1/ -t collectd.postcodeinfo.*.df.root.df_complex.used --auth $GRAFANA_BEARER_TOKEN --below -w 3 -c 2 -n 'Number of hosts'

This will alert with a warning if < 3 hosts have sent data, and critical if < 2.
