### PR TITLE
Fix stale / dead hosts issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,14 @@
 
 [Installation and Setup](http://sensu-plugins.io/docs/installation_instructions.html)
 
+## What's "999" value?
+
+999 value for data age has been implemented as a 'dummy value' which should be used to ignore stale hosts issues throwing errors like
+
+```
+CheckGraphiteData UNKNOWN: Graphite data age is past allowed threshold (180 seconds)
+```
+
+When value 999 is used data age checks are not performed.
+
 ## Notes

--- a/bin/check-graphite-data.rb
+++ b/bin/check-graphite-data.rb
@@ -79,8 +79,10 @@ class CheckGraphiteData < Sensu::Plugin::Check::CLI
 
   # Check the age of the data being processed
   def check_age
-    if (Time.now.to_i - @value['end']) > config[:allowed_graphite_age] && config[:allowed_graphite_age] != 999
-      unknown "Graphite data age is past allowed threshold (#{config[:allowed_graphite_age]} seconds)"
+    if config[:allowed_graphite_age] != 999
+      if ((Time.now.to_i - @value['end']) > config[:allowed_graphite_age])
+        unknown "Graphite data age is past allowed threshold (#{config[:allowed_graphite_age]} seconds)"
+      end
     end
   end
 
@@ -156,14 +158,14 @@ class CheckGraphiteData < Sensu::Plugin::Check::CLI
 
   # Check if value is below defined threshold
   def below?(type)
-    if ! @data.nil?
+    if ! @data.last.nil?
       config[:below] && @data.last < config[type]
     end
   end
 
   # Check is value is above defined threshold
   def above?(type)
-    if ! @data.nil?
+    if ! @data.last.nil?
       (!config[:below]) && (@data.last > config[type]) && (!decreased?)
     end
   end

--- a/lib/sensu-plugins-graphite/version.rb
+++ b/lib/sensu-plugins-graphite/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsGraphite
   module Version
     MAJOR = 0
     MINOR = 0
-    PATCH = 8
+    PATCH = 9
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION
Checks failing with

```
GRAPHITE-ERRORS: CheckGraphiteData UNKNOWN: Graphite data age is past allowed threshold (180 seconds)
GRAPHITE-METRICS-RECEIVED: CheckGraphiteData UNKNOWN: Graphite data age is past allowed threshold (180 seconds)
```

Should work now when switch

```
-a 999
```

is used
